### PR TITLE
npm scripts works on the Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "dev": "run-p dev:*",
     "start": "eleventy --serve",
     "build": "run-s clean build:assets build:site",
-    "dev:assets": "APP_ENV=development webpack --mode production --watch",
-    "dev:site": "APP_ENV=development eleventy --serve",
+    "dev:assets": "env APP_ENV=development webpack --mode production --watch",
+    "dev:site": "env APP_ENV=development eleventy --serve",
     "build:assets": "webpack --mode production",
     "build:site": "eleventy",
     "clean": "rm -rf ./public"


### PR DESCRIPTION
npm scripts "dev:assets" and "dev:site" don't work on the Windows OS.