### PR TITLE
Add permalink field to posts

### DIFF
--- a/.forestry/front_matter/templates/post.yml
+++ b/.forestry/front_matter/templates/post.yml
@@ -14,3 +14,8 @@ fields:
 - type: textarea
   name: description
   label: description
+- name: permalink
+  type: text
+  label: Permalink
+  default: posts/{{ title | slug }}/index.html
+  hidden: true

--- a/src/posts/a-post-with-code-samples.md
+++ b/src/posts/a-post-with-code-samples.md
@@ -1,6 +1,7 @@
 ---
 title: A post with code samples
 description: Health goth raw denim vaporware waistcoat, vegan neutra glossier. Cronut chartreuse tbh meh schlitz. Snackwave lumbersexual pinterest narwhal.
+permalink: posts/{{ title | slug }}/index.html
 date: '2020-11-18'
 tags: [demo-content, code]
 ---

--- a/src/posts/a-post-with-mermaid-charts.md
+++ b/src/posts/a-post-with-mermaid-charts.md
@@ -1,6 +1,7 @@
 ---
 title: A post with mermaid charts
 description: Health goth raw denim vaporware waistcoat, vegan neutra glossier. Cronut chartreuse tbh meh schlitz. Snackwave lumbersexual pinterest narwhal.
+permalink: posts/{{ title | slug }}/index.html
 date: '2021-03-22'
 tags: [demo-content, code, mermaid]
 ---

--- a/src/posts/a-post-with-rich-media.md
+++ b/src/posts/a-post-with-rich-media.md
@@ -3,6 +3,7 @@ title: A post with rich media
 date: '2020-12-20'
 tags: [demo-content, media]
 decription: The last person we talked to said this would be ready action item, and what do you feel you would bring to the table if you were hired for this position bells and whistles.
+permalink: posts/{{ title | slug }}/index.html
 ---
 
 The last person we talked to said this would be ready action item, and what do you feel you would bring to the table if you were hired for this position bells and whistles. Rock Star/Ninja UI put a record on and see who dances, or cannibalize. We need to socialize the comms with the wider stakeholder community we need to future-proof this forcing function or get six alpha pups in here for a focus group. Helicopter view quarterly sales are at an all-time low so future-proof going forward we’re ahead of the curve on that one yet due diligence, so get buy-in. Back to the drawing-board action item get six alpha pups in here for a focus group ramp up.

--- a/src/posts/a-simple-post.md
+++ b/src/posts/a-simple-post.md
@@ -3,6 +3,7 @@ title: A simple post
 date: '2020-10-18'
 tags: [demo-content, simple-post]
 description: Meditation gentrify fam, yuccie kickstarter brunch vape. Pitchfork freegan biodiesel bicycle rights. Semiotics flexitarian four loko XOXO raw denim chartreuse.
+permalink: posts/{{ title | slug }}/index.html
 ---
 
 Meditation gentrify fam, yuccie kickstarter brunch vape. Pitchfork freegan biodiesel bicycle rights. Semiotics flexitarian four loko XOXO raw denim chartreuse. Cray ramps microdosing everyday carry bicycle rights

--- a/src/posts/another-post-with-code-samples.md
+++ b/src/posts/another-post-with-code-samples.md
@@ -1,6 +1,7 @@
 ---
 title: Another post with code samples
 description: Health goth raw denim vaporware waistcoat, vegan neutra glossier. Cronut chartreuse tbh meh schlitz. Snackwave lumbersexual pinterest narwhal.
+permalink: posts/{{ title | slug }}/index.html
 date: '2020-11-19'
 tags: [demo-content, code]
 ---

--- a/src/posts/another-post-with-rich-media.md
+++ b/src/posts/another-post-with-rich-media.md
@@ -3,6 +3,7 @@ title: Another post with rich media
 date: '2020-12-21'
 tags: [demo-content, media]
 decription: The last person we talked to said this would be ready action item, and what do you feel you would bring to the table if you were hired for this position bells and whistles.
+permalink: posts/{{ title | slug }}/index.html
 ---
 
 The last person we talked to said this would be ready action item, and what do you feel you would bring to the table if you were hired for this position bells and whistles. Rock Star/Ninja UI put a record on and see who dances, or cannibalize. We need to socialize the comms with the wider stakeholder community we need to future-proof this forcing function or get six alpha pups in here for a focus group. Helicopter view quarterly sales are at an all-time low so future-proof going forward we’re ahead of the curve on that one yet due diligence, so get buy-in. Back to the drawing-board action item get six alpha pups in here for a focus group ramp up.

--- a/src/posts/another-simple-post.md
+++ b/src/posts/another-simple-post.md
@@ -3,6 +3,7 @@ title: Another simple post
 date: '2020-10-22'
 tags: [demo-content, simple-post]
 description: Meditation gentrify fam, yuccie kickstarter brunch vape. Pitchfork freegan biodiesel bicycle rights. Semiotics flexitarian four loko XOXO raw denim chartreuse.
+permalink: posts/{{ title | slug }}/index.html
 ---
 
 Meditation gentrify fam, yuccie kickstarter brunch vape. Pitchfork freegan biodiesel bicycle rights. Semiotics flexitarian four loko XOXO raw denim chartreuse. Cray ramps microdosing everyday carry bicycle rights

--- a/src/posts/even-yet-another-post-with-code-samples.md
+++ b/src/posts/even-yet-another-post-with-code-samples.md
@@ -1,6 +1,7 @@
 ---
 title: Even yet another post with code samples
 description: Health goth raw denim vaporware waistcoat, vegan neutra glossier. Cronut chartreuse tbh meh schlitz. Snackwave lumbersexual pinterest narwhal.
+permalink: posts/{{ title | slug }}/index.html
 date: '2020-11-23'
 tags: [demo-content, code]
 ---

--- a/src/posts/even-yet-another-post-with-rich-media.md
+++ b/src/posts/even-yet-another-post-with-rich-media.md
@@ -3,6 +3,7 @@ title: Even yet another post with rich media
 date: '2020-12-24'
 tags: [demo-content, media]
 decription: The last person we talked to said this would be ready action item, and what do you feel you would bring to the table if you were hired for this position bells and whistles.
+permalink: posts/{{ title | slug }}/index.html
 ---
 
 The last person we talked to said this would be ready action item, and what do you feel you would bring to the table if you were hired for this position bells and whistles. Rock Star/Ninja UI put a record on and see who dances, or cannibalize. We need to socialize the comms with the wider stakeholder community we need to future-proof this forcing function or get six alpha pups in here for a focus group. Helicopter view quarterly sales are at an all-time low so future-proof going forward we’re ahead of the curve on that one yet due diligence, so get buy-in. Back to the drawing-board action item get six alpha pups in here for a focus group ramp up.

--- a/src/posts/even-yet-another-simple-post.md
+++ b/src/posts/even-yet-another-simple-post.md
@@ -3,6 +3,7 @@ title: Even yet another simple post
 date: '2020-10-25'
 tags: [demo-content, simple-post]
 description: Meditation gentrify fam, yuccie kickstarter brunch vape. Pitchfork freegan biodiesel bicycle rights. Semiotics flexitarian four loko XOXO raw denim chartreuse.
+permalink: posts/{{ title | slug }}/index.html
 ---
 
 Meditation gentrify fam, yuccie kickstarter brunch vape. Pitchfork freegan biodiesel bicycle rights. Semiotics flexitarian four loko XOXO raw denim chartreuse. Cray ramps microdosing everyday carry bicycle rights

--- a/src/posts/yet-another-post-with-code-samples.md
+++ b/src/posts/yet-another-post-with-code-samples.md
@@ -1,6 +1,7 @@
 ---
 title: Yet another post with code samples
 description: Health goth raw denim vaporware waistcoat, vegan neutra glossier. Cronut chartreuse tbh meh schlitz. Snackwave lumbersexual pinterest narwhal.
+permalink: posts/{{ title | slug }}/index.html
 date: '2020-11-26'
 tags: [demo-content, code]
 ---

--- a/src/posts/yet-another-post-with-rich-media.md
+++ b/src/posts/yet-another-post-with-rich-media.md
@@ -3,6 +3,7 @@ title: Yet another post with rich media
 date: '2020-12-28'
 tags: [demo-content, media]
 decription: The last person we talked to said this would be ready action item, and what do you feel you would bring to the table if you were hired for this position bells and whistles.
+permalink: posts/{{ title | slug }}/index.html
 ---
 
 The last person we talked to said this would be ready action item, and what do you feel you would bring to the table if you were hired for this position bells and whistles. Rock Star/Ninja UI put a record on and see who dances, or cannibalize. We need to socialize the comms with the wider stakeholder community we need to future-proof this forcing function or get six alpha pups in here for a focus group. Helicopter view quarterly sales are at an all-time low so future-proof going forward we’re ahead of the curve on that one yet due diligence, so get buy-in. Back to the drawing-board action item get six alpha pups in here for a focus group ramp up.

--- a/src/posts/yet-another-simple-post.md
+++ b/src/posts/yet-another-simple-post.md
@@ -6,6 +6,7 @@ tags:
 - simple-post
 description: Meditation gentrify fam, yuccie kickstarter brunch vape. Pitchfork freegan
   biodiesel bicycle rights. Semiotics flexitarian four loko XOXO raw denim chartreuse.
+permalink: posts/{{ title | slug }}/index.html
 
 ---
 Meditation gentrify fam, yuccie kickstarter brunch vape. Pitchfork freegan biodiesel bicycle rights. Semiotics flexitarian four loko XOXO raw denim chartreuse. Cray ramps microdosing everyday carry bicycle rights


### PR DESCRIPTION
**Changes:**
- Add `permalink field to posts
- Add permalink field to forestry config

**Why:**
You can change the URL by manipulating the file name. Adding permalink support more flexible paths other than `posts/[filename]`.

**Note:**
By default `path` is created from the title.