### PR TITLE
Update .eleventy so configuration options work

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -136,11 +136,11 @@ module.exports = function (eleventyConfig) {
       output: 'public',
       includes: 'includes',
       data: 'data',
-      layouts: 'layouts',
-      passthroughFileCopy: true,
-      templateFormats: ['html', 'njk', 'md'],
-      htmlTemplateEngine: 'njk',
-      markdownTemplateEngine: 'njk',
+      layouts: 'layouts'
     },
+    passthroughFileCopy: true,
+    templateFormats: ['html', 'njk', 'md'],
+    htmlTemplateEngine: 'njk',
+    markdownTemplateEngine: 'njk',
   };
 };


### PR DESCRIPTION
In the object returned by `eleventyConfig` the configuration options `passthroughFileCopy`, `templateFormats`, `htmlTemplateEngine` and `markdownTemplateEngine` were included in the `dir` object giving the directory structure, so were not being picked up by eleventy. I've moved them out to the returned object.