### PR TITLE
fix render error in sitemap

### DIFF
--- a/src/sitemap.njk
+++ b/src/sitemap.njk
@@ -2,7 +2,6 @@
 permalink: /sitemap.xml
 eleventyExcludeFromCollections: true
 ---
-
 <?xml version="1.0" encoding="utf-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   {% for item in collections.all %}


### PR DESCRIPTION
There is an error which prevents sitemap from rendering. This PR fixes it. The error was due to the first line of xml being blank.

![image](https://user-images.githubusercontent.com/4337699/169404848-71cb9289-9e5c-4dc9-9887-b98dd5c32c56.png)
