### PR TITLE
Fix h4 heading font-size

### DIFF
--- a/src/css/typography.css
+++ b/src/css/typography.css
@@ -51,7 +51,7 @@ h4 {
   font-size: var(--text-xl);
 }
 
-h4 {
+h5 {
   font-size: var(--text-lg);
 }
 


### PR DESCRIPTION
`h4` headings were previously set to text-lg, identical to `p` due to a typo. This was removed so that h4 headings are now the correct size of text-xl